### PR TITLE
Use correct term

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installing from PyPI
 
 This section assumes that an OMERO.py is already installed.
 
-Install the app using `pip <https://pip.pypa.io/en/stable/>`_:
+Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
 ::
 


### PR DESCRIPTION
Use command-line tool instead of app

The term was used by error when copying/pasting readme from web app
cc @joshmoore 