### PR TITLE
0.2 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 build
 dist
 omero-cli-duplicate-*
-src/omero_cli_duplicate.egg-info
+*.egg*
+.cache
+*.DS_Store
+.*un~
+*.pyc
+.omero

--- a/.omeroci/README
+++ b/.omeroci/README
@@ -1,0 +1,2 @@
+This directory implements scripts to unify
+build and release actions across repos.

--- a/.omeroci/bump-version
+++ b/.omeroci/bump-version
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+from argparse import ArgumentParser
+from fileinput import input
+from os.path import dirname
+from os.path import join
+from os.path import pardir
+from re import compile
+
+setup_file = join(dirname(__file__), pardir, "setup.py")
+setup_re = compile("^(version\s=\s')\S+(')$")
+
+def replace_version(file, re, version):
+    for line in input([file], inplace=1):
+        replacement = r"\g<1>%s\g<2>" % version
+        print re.sub(replacement, line),
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+    replace_version(setup_file, setup_re, args.version)

--- a/.omeroci/release
+++ b/.omeroci/release
@@ -1,0 +1,13 @@
+#!/usr/bin/env make -f
+release:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+	git describe --exact
+	python setup.py sdist
+	echo twine upload dist/omero-cli-duplicate-$(VERSION).tar.gz
+
+clean:
+	rm -rf build dist omero-cli-duplicate.egg-info *.pyc
+
+.PHONY: release clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: python
-# This (sudo: false) is needed to "run on container-based infrastructure" on
-# which cache: is available
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+
+virtualenv:
+  system_site_packages: true
+
 sudo: required
 
+services:
+  - docker
+
 before_install:
-  - pip install restructuredtext_lint
-  - pip install flake8 pycodestyle pep8-naming
-  - flake8 .
-  - rst-lint README.rst
-  - export PATH=/usr/bin/:$PATH
+  - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
 
 script:
-    - sudo python setup.py sdist install --record files.txt
-    - cat files.txt | xargs sudo rm -rf
-    - sudo python setup.py bdist_egg
-    - easy_install dist/*.egg
+  - .omero/cli-docker

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
 Changes
 =======
 
+0.2 - Jan 19, 2018
+==================
+* Update to match https://github.com/ome/omero-cli-render/pull/1
 
 0.1 - April 28, 2016
 ====================

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installing from PyPI
 
 This section assumes that an OMERO.py is already installed.
 
-Install the app using `pip <https://pip.pypa.io/en/stable/>`_:
+Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,69 @@
 #
 #
 import os
+import sys
 
 from setuptools import setup
+from setuptools.command.test import test as test_command
+
+
+class PyTest(test_command):
+    user_options = [
+        ('test-path=', 't', "base dir for test collection"),
+        ('test-ice-config=', 'i',
+         "use specified 'ice config' file instead of default"),
+        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-no-capture', 's', "don't suppress test output"),
+        ('test-failfast', 'x', "Exit on first error"),
+        ('test-verbose', 'v', "more verbose output"),
+        ('test-quiet', 'q', "less verbose output"),
+        ('junitxml=', None, "create junit-xml style report file at 'path'"),
+        ('pdb', None, "fallback to pdb on error"),
+        ]
+
+    def initialize_options(self):
+        test_command.initialize_options(self)
+        self.test_pythonpath = None
+        self.test_string = None
+        self.test_marker = None
+        self.test_path = 'test'
+        self.test_failfast = False
+        self.test_quiet = False
+        self.test_verbose = False
+        self.test_no_capture = False
+        self.junitxml = None
+        self.pdb = False
+        self.test_ice_config = None
+
+    def finalize_options(self):
+        test_command.finalize_options(self)
+        self.test_args = [self.test_path]
+        if self.test_string is not None:
+            self.test_args.extend(['-k', self.test_string])
+        if self.test_marker is not None:
+            self.test_args.extend(['-m', self.test_marker])
+        if self.test_failfast:
+            self.test_args.extend(['-x'])
+        if self.test_verbose:
+            self.test_args.extend(['-v'])
+        if self.test_quiet:
+            self.test_args.extend(['-q'])
+        if self.junitxml is not None:
+            self.test_args.extend(['--junitxml', self.junitxml])
+        if self.pdb:
+            self.test_args.extend(['--pdb'])
+        self.test_suite = True
+        if 'ICE_CONFIG' not in os.environ:
+            os.environ['ICE_CONFIG'] = self.test_ice_config
+
+    def run_tests(self):
+        if self.test_pythonpath is not None:
+            sys.path.insert(0, self.test_pythonpath)
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
 
 def read(fname):
@@ -30,12 +91,12 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.1.0'
+version = '0.2.0'
 url = "https://github.com/ome/omero-cli-duplicate/"
 
 setup(
     version=version,
-    packages=['omero.plugins'],
+    packages=['', 'omero.plugins'],
     package_dir={"": "src"},
     name='omero-cli-duplicate',
     description="Plugin for use in the OMERO CLI.",
@@ -57,6 +118,9 @@ setup(
     author_email='ome-devel@lists.openmicroscopy.org.uk',
     license='GPL-2.0+',
     url='%s' % url,
+    zip_safe=False,
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
+    cmdclass={'test': PyTest},
+    tests_require=['pytest', 'restview', 'mox'],
 )

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import pytest
+
+import omero
+from omero.cli import CLI
+from omero.plugins.sessions import SessionsControl
+from omero.rtypes import rstring
+
+from omero.testlib import ITest
+from omero_ext.mox import Mox
+
+
+class AbstractCLITest(ITest):
+
+    @classmethod
+    def setup_class(cls):
+        super(AbstractCLITest, cls).setup_class()
+        cls.cli = CLI()
+        cls.cli.register("sessions", SessionsControl, "TEST")
+
+    def setup_mock(self):
+        self.mox = Mox()
+
+    def teardown_mock(self):
+        self.mox.UnsetStubs()
+        self.mox.VerifyAll()
+
+
+class CLITest(AbstractCLITest):
+
+    def setup_method(self, method):
+        self.args = self.login_args()
+
+    def create_object(self, object_type, name=""):
+        # create object
+        if object_type == 'Dataset':
+            new_object = omero.model.DatasetI()
+        elif object_type == 'Project':
+            new_object = omero.model.ProjectI()
+        elif object_type == 'Plate':
+            new_object = omero.model.PlateI()
+        elif object_type == 'Screen':
+            new_object = omero.model.ScreenI()
+        elif object_type == 'Image':
+            new_object = self.new_image()
+        new_object.name = rstring(name)
+        new_object = self.update.saveAndReturnObject(new_object)
+
+        # check object has been created
+        found_object = self.query.get(object_type, new_object.id.val)
+        assert found_object.id.val == new_object.id.val
+
+        return new_object.id.val
+
+    @pytest.fixture()
+    def simple_hierarchy(self):
+        proj = self.make_project()
+        dset = self.make_dataset()
+        img = self.update.saveAndReturnObject(self.new_image())
+        self.link(proj, dset)
+        self.link(dset, img)
+        return proj, dset, img
+
+
+class RootCLITest(AbstractCLITest):
+
+    def setup_method(self, method):
+        self.args = self.root_login_args()
+
+
+class ArgumentFixture(object):
+
+    """
+    Used to test the user/group argument
+    """
+
+    def __init__(self, prefix, attr):
+        self.prefix = prefix
+        self.attr = attr
+
+    def get_arguments(self, obj):
+        args = []
+        if self.prefix:
+            args += [self.prefix]
+        if self.attr:
+            args += ["%s" % getattr(obj, self.attr).val]
+        return args
+
+    def __repr__(self):
+        if self.prefix:
+            return "%s" % self.prefix
+        else:
+            return "%s" % self.attr
+
+
+UserIdNameFixtures = (
+    ArgumentFixture('--id', 'id'),
+    ArgumentFixture('--name', 'omeName'),
+    )
+
+UserFixtures = (
+    ArgumentFixture(None, 'id'),
+    ArgumentFixture(None, 'omeName'),
+    ArgumentFixture('--user-id', 'id'),
+    ArgumentFixture('--user-name', 'omeName'),
+    )
+
+GroupIdNameFixtures = (
+    ArgumentFixture('--id', 'id'),
+    ArgumentFixture('--name', 'name'),
+    )
+
+GroupFixtures = (
+    ArgumentFixture(None, 'id'),
+    ArgumentFixture(None, 'name'),
+    ArgumentFixture('--group-id', 'id'),
+    ArgumentFixture('--group-name', 'name'),
+    )
+
+
+def get_user_ids(out, sort_key=None):
+    columns = {'login': 1, 'first-name': 2, 'last-name': 3, 'email': 4}
+    lines = out.split('\n')
+    ids = []
+    last_value = None
+    for line in lines[2:]:
+        elements = line.split('|')
+        if len(elements) < 8:
+            continue
+
+        ids.append(int(elements[0].strip()))
+        if sort_key:
+            if sort_key == 'id':
+                new_value = ids[-1]
+            else:
+                new_value = elements[columns[sort_key]].strip()
+            assert new_value >= last_value
+            last_value = new_value
+    return ids
+
+
+def get_group_ids(out, sort_key=None):
+    lines = out.split('\n')
+    ids = []
+    last_value = None
+    for line in lines[2:]:
+        elements = line.split('|')
+        if len(elements) < 4:
+            continue
+
+        ids.append(int(elements[0].strip()))
+        if sort_key:
+            if sort_key == 'id':
+                new_value = ids[-1]
+            else:
+                new_value = elements[1].strip()
+            assert new_value >= last_value
+            last_value = new_value
+    return ids

--- a/test/integration/clitest/test_duplicate.py
+++ b/test/integration/clitest/test_duplicate.py
@@ -144,7 +144,7 @@ class TestDuplicate(CLITest):
         # Check object has been duplicated
         assert len(objs) == 1
         assert objs[0].id.val == oid
-        assert len(lines_out) == 6
+        assert len(lines_out) == 7
         assert '%s:%s' % (object_type, objs[0].id.val) in out
         # Check object has been found in two different places of the output
         assert out.find(obj_arg) != out.rfind(obj_arg)

--- a/test/integration/clitest/test_duplicate.py
+++ b/test/integration/clitest/test_duplicate.py
@@ -21,7 +21,7 @@
 
 import omero
 from omero.plugins.duplicate import DuplicateControl
-from test.integration.clitest.cli import CLITest
+from cli import CLITest
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]


### PR DESCRIPTION
Update `omero-cli-duplicate` to match https://github.com/ome/omero-cli-render/pull/1, using https://github.com/openmicroscopy/omero-test-infra to run all integration tests in Travis (now passing).

Propose releasing as 0.2.0.

cc: @dominikl @jburel @pwalczysko 