### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
+---
 language: python
-
-virtualenv:
-  system_site_packages: true
-
 sudo: required
 
 services:
   - docker
 
 before_install:
-  - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
+  - git clone git://github.com/ome/omero-test-infra .omero
 
 script:
   - .omero/cli-docker
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],  # Get strings from
           # http://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -120,7 +121,14 @@ setup(
     url='%s' % url,
     zip_safe=False,
     download_url='%s/v%s.tar.gz' % (url, version),
+    install_requires=[
+        'omero-py>=5.6.dev4',
+        'future'
+    ],
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
-    tests_require=['pytest', 'restview', 'mox'],
+    tests_require=[
+        'pytest',
+        'restview',
+        'mox3'],
 )

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.2.0'
+version = '0.3.dev1'
 url = "https://github.com/ome/omero-cli-duplicate/"
 
 setup(

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import object
 import pytest
 
 import omero
@@ -28,7 +29,7 @@ from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
 
 from omero.testlib import ITest
-from omero_ext.mox import Mox
+from mox3 import mox
 
 
 class AbstractCLITest(ITest):
@@ -40,7 +41,7 @@ class AbstractCLITest(ITest):
         cls.cli.register("sessions", SessionsControl, "TEST")
 
     def setup_mock(self):
-        self.mox = Mox()
+        self.mox = mox.Mox()
 
     def teardown_mock(self):
         self.mox.UnsetStubs()


### PR DESCRIPTION
- futurize the codebase
- update Travis CI to run on Python 3 and deploy artifacts to PyPI

Proposed tag: `0.3.dev1`