### PR TITLE
Provide further command-line options.

### DIFF
--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -53,10 +53,11 @@ Examples:
 
     # Duplicate a project with its datasets but not their images
     omero duplicate Project:15 --ignore-classes=DatasetImageLink
-    # Duplicate a project with the original images linked into its datasets
+    # Duplicate a project with the original images linked from its datasets
     omero duplicate Project:15 --reference-classes=Image
-    # Reuse annotations except for duplicating comments and ratings
 """
+        "    # Duplicate a project, linking to the original annotations "
+        "except for duplicating the comments and ratings\n"
         "    omero duplicate Project:15 --reference-classes=Annotation "
         "--duplicate-classes=CommentAnnotation,LongAnnotation\n\n")
 
@@ -71,16 +72,16 @@ class DuplicateControl(GraphControl):
     def _pre_objects(self, parser):
         parser.add_argument(
             "--duplicate-classes",
-            help=("Modifies the given option by specifying "
-                  "classes to duplicate"))
+            help=("Modifies the given option by specifying kinds of object to "
+                  "duplicate"))
         parser.add_argument(
             "--reference-classes",
-            help=("Modifies the given option by specifying "
-                  "classes to reference"))
+            help=("Modifies the given option by specifying kinds of object to "
+                  "link to instead of duplicate"))
         parser.add_argument(
             "--ignore-classes",
-            help=("Modifies the given option by specifying "
-                  "classes to ignore"))
+            help=("Modifies the given option by specifying kinds of object to "
+                  "ignore, neither linking to nor duplicating"))
 
     def _process_request(self, req, args, client):
         import omero.cmd

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -30,6 +30,14 @@ from omero.cli import CLI, GraphControl
 
 HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 
+By default, a whole subtree of OMERO model objects is duplicated. One
+may opt to have duplicate objects reference original parts of the
+subtree instead of also duplicating those, see the "--reference" option
+below. More strongly, one may "--ignore" given kinds of model object
+such that they are not included among the duplicate in any way; if using
+this option then read on to the warning below about ignoring a linked-to
+class.
+
 Examples:
 
     # Duplicate a dataset

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -74,15 +74,18 @@ class DuplicateControl(GraphControl):
         parser.add_argument(
             "--duplicate",
             help=("Modifies the given option by specifying kinds of object to "
-                  "duplicate"))
+                  "duplicate"),
+            metavar="CLASS")
         parser.add_argument(
             "--reference",
             help=("Modifies the given option by specifying kinds of object to "
-                  "link to instead of duplicate"))
+                  "link to instead of duplicate"),
+            metavar="CLASS")
         parser.add_argument(
             "--ignore",
             help=("Modifies the given option by specifying kinds of object to "
-                  "ignore, neither linking to nor duplicating"))
+                  "ignore, neither linking to nor duplicating"),
+            metavar="CLASS")
 
     def _process_request(self, req, args, client):
         import omero.cmd

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -73,17 +73,16 @@ class DuplicateControl(GraphControl):
     def _pre_objects(self, parser):
         parser.add_argument(
             "--duplicate",
-            help=("Modifies the given option by specifying kinds of object to "
-                  "duplicate"),
+            help="Specify kinds of object to duplicate",
             metavar="CLASS")
         parser.add_argument(
             "--reference",
-            help=("Modifies the given option by specifying kinds of object to "
+            help=("Specify kinds of object to "
                   "link to instead of duplicate"),
             metavar="CLASS")
         parser.add_argument(
             "--ignore",
-            help=("Modifies the given option by specifying kinds of object to "
+            help=("Specify kinds of object to "
                   "ignore, neither linking to nor duplicating"),
             metavar="CLASS")
 

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -82,17 +82,20 @@ class DuplicateControl(GraphControl):
         parser.add_argument(
             "--duplicate",
             help="Specify kinds of object to duplicate",
-            metavar="CLASS")
+            metavar="CLASS",
+            nargs="+", type=lambda s: s.split(","), action="append")
         parser.add_argument(
             "--reference",
             help=("Specify kinds of object to "
                   "link to instead of duplicate"),
-            metavar="CLASS")
+            metavar="CLASS",
+            nargs="+", type=lambda s: s.split(","), action="append")
         parser.add_argument(
             "--ignore",
             help=("Specify kinds of object to "
                   "ignore, neither linking to nor duplicating"),
-            metavar="CLASS")
+            metavar="CLASS",
+            nargs="+", type=lambda s: s.split(","), action="append")
 
     def _process_request(self, req, args, client):
         import omero.cmd
@@ -101,14 +104,15 @@ class DuplicateControl(GraphControl):
         else:
             requests = [req]
         for request in requests:
+            from itertools import chain
             if isinstance(request, omero.cmd.SkipHead):
                 request = request.request
             if args.duplicate:
-                request.typesToDuplicate = args.duplicate.split(",")
+                request.typesToDuplicate = list(chain(*chain(*args.duplicate)))
             if args.reference:
-                request.typesToReference = args.reference.split(",")
+                request.typesToReference = list(chain(*chain(*args.reference)))
             if args.ignore:
-                request.typesToIgnore = args.ignore.split(",")
+                request.typesToIgnore = list(chain(*chain(*args.ignore)))
 
         super(DuplicateControl, self)._process_request(req, args, client)
 

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -56,12 +56,12 @@ Examples:
         "    omero duplicate Project:15 --reference-classes=Annotation "
         "--duplicate-classes=CommentAnnotation,LongAnnotation\n"
         """
-Group permissions can prevent a duplicated link from referencing another user's Image or Annotation.
-However, note that ignoring a linked-to class does not suffice, one must
-ignore the link itself. For instance, ignore ImageAnnotationLink or
-IAnnotationLink rather than the target Annotation. This is not an issue
-for classes such as Roi which can be ignored directly because they have
-no separate link class.
+Group permissions can prevent a duplicated link from referencing another
+user's Image or Annotation. However, note that ignoring a linked-to
+class does not suffice, one must ignore the link itself. For instance,
+ignore ImageAnnotationLink or IAnnotationLink rather than the target
+Annotation. This is not an issue for classes such as Roi which can be
+ignored directly because they have no separate link class.
 """)
 
 

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -28,9 +28,7 @@ import sys
 
 from omero.cli import CLI, GraphControl
 
-HELP = ("""Duplicate OMERO data.
-
-Duplicate entire graphs of data based on the ID of the top-node.
+HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 
 Examples:
 

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -56,7 +56,7 @@ Examples:
         "    omero duplicate Project:15 --reference-classes=Annotation "
         "--duplicate-classes=CommentAnnotation,LongAnnotation\n"
         """
-Group permissions can prevent simply referencing an Image or Annotation.
+Group permissions can prevent a duplicated link from referencing another user's Image or Annotation.
 However, note that ignoring a linked-to class does not suffice, one must
 ignore the link itself. For instance, ignore ImageAnnotationLink or
 IAnnotationLink rather than the target Annotation. This is not an issue

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -47,14 +47,14 @@ Examples:
     omero duplicate Dataset:53 --dry-run --report
 
     # Duplicate a project with its datasets but not their images
-    omero duplicate Project:15 --ignore-classes=DatasetImageLink
+    omero duplicate Project:15 --ignore=DatasetImageLink
     # Duplicate a project with the original images linked from its datasets
-    omero duplicate Project:15 --reference-classes=Image
+    omero duplicate Project:15 --reference=Image
 """
         "    # Duplicate a project, linking to the original annotations "
         "except for duplicating the comments and ratings\n"
-        "    omero duplicate Project:15 --reference-classes=Annotation "
-        "--duplicate-classes=CommentAnnotation,LongAnnotation\n"
+        "    omero duplicate Project:15 --reference=Annotation "
+        "--duplicate=CommentAnnotation,LongAnnotation\n"
         """
 Group permissions can prevent a duplicated link from referencing another
 user's Image or Annotation. However, note that ignoring a linked-to
@@ -74,15 +74,15 @@ class DuplicateControl(GraphControl):
 
     def _pre_objects(self, parser):
         parser.add_argument(
-            "--duplicate-classes",
+            "--duplicate",
             help=("Modifies the given option by specifying kinds of object to "
                   "duplicate"))
         parser.add_argument(
-            "--reference-classes",
+            "--reference",
             help=("Modifies the given option by specifying kinds of object to "
                   "link to instead of duplicate"))
         parser.add_argument(
-            "--ignore-classes",
+            "--ignore",
             help=("Modifies the given option by specifying kinds of object to "
                   "ignore, neither linking to nor duplicating"))
 
@@ -95,12 +95,12 @@ class DuplicateControl(GraphControl):
         for request in requests:
             if isinstance(request, omero.cmd.SkipHead):
                 request = request.request
-            if args.duplicate_classes:
-                request.typesToDuplicate = args.duplicate_classes.split(",")
-            if args.reference_classes:
-                request.typesToReference = args.reference_classes.split(",")
-            if args.ignore_classes:
-                request.typesToIgnore = args.ignore_classes.split(",")
+            if args.duplicate:
+                request.typesToDuplicate = args.duplicate.split(",")
+            if args.reference:
+                request.typesToReference = args.reference.split(",")
+            if args.ignore:
+                request.typesToIgnore = args.ignore.split(",")
 
         super(DuplicateControl, self)._process_request(req, args, client)
 

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -33,9 +33,9 @@ HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 By default, a whole subtree of OMERO model objects is duplicated. One
 may opt to have duplicate objects reference original parts of the
 subtree instead of also duplicating those, see the "--reference" option
-below. More strongly, one may "--ignore" given kinds of object
-such that they are not included among the duplicate in any way; if using
-this option then read on to the warning below about ignoring a linked-to
+below. More strongly, one may "--ignore" given kinds of object such that
+they are not included among the duplicate in any way; if using this
+option then read on to the warning below about ignoring a linked-to
 class.
 
 Examples:
@@ -63,10 +63,10 @@ Examples:
         "--duplicate=CommentAnnotation,LongAnnotation\n"
         """
 Group permissions can prevent a duplicated link from referencing another
-user's Image or Annotation, causing a duplication error.
-However, using "--ignore" instead of "--reference" for a linked-to
-class does not suffice, one must ignore the link itself. For instance,
-ignore ImageAnnotationLink or IAnnotationLink rather than the target
+user's Image or Annotation, causing a duplication error. However, using
+"--ignore" instead of "--reference" for a linked-to class does not
+suffice, one must ignore the link itself. For instance, ignore
+ImageAnnotationLink or IAnnotationLink rather than the target
 Annotation. This is not an issue for classes such as Roi which can be
 ignored directly because they have no separate link class.
 """)

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -33,9 +33,9 @@ HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 By default, a whole subtree of OMERO model objects is duplicated. One
 may opt to have duplicate objects reference original parts of the
 subtree instead of also duplicating those, see the "--reference" option
-below. More strongly, one may "--ignore" given kinds of model objects such that
-they are not included among the duplicate in any way; if using this
-option then read on to the warning below about ignoring a linked-to
+below. More strongly, one may "--ignore" given kinds of model objects
+such that they are not included among the duplicate in any way; if using
+this option then read on to the warning below about ignoring a linked-to
 class.
 
 Examples:

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -32,11 +32,6 @@ HELP = ("""Duplicate OMERO data.
 
 Duplicate entire graphs of data based on the ID of the top-node.
 
-Note that no object that corresponds to a file on disk will be duplicated.
-In some circumstances a duplicate object may reference an original object that
-does have associated binary data but a duplicated image should not be expected
-to include any pixel data.
-
 Examples:
 
     # Duplicate a dataset

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -53,14 +53,14 @@ Examples:
     omero duplicate Dataset:53 --dry-run --report
 
     # Duplicate a project with its datasets but not their images
-    omero duplicate Project:15 --ignore=DatasetImageLink
+    omero duplicate Project:15 --ignore DatasetImageLink
     # Duplicate a project with the original images linked from its datasets
-    omero duplicate Project:15 --reference=Image
+    omero duplicate Project:15 --reference Image
 """
         "    # Duplicate a project, linking to the original annotations "
         "except for duplicating the comments and ratings\n"
-        "    omero duplicate Project:15 --reference=Annotation "
-        "--duplicate=CommentAnnotation,LongAnnotation\n"
+        "    omero duplicate Project:15 --reference Annotation "
+        "--duplicate CommentAnnotation,LongAnnotation\n"
         """
 Group permissions can prevent a duplicated link from referencing another
 user's Image or Annotation, causing a duplication error. However, using

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -33,7 +33,7 @@ HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 By default, a whole subtree of OMERO model objects is duplicated. One
 may opt to have duplicate objects reference original parts of the
 subtree instead of also duplicating those, see the "--reference" option
-below. More strongly, one may "--ignore" given kinds of model object
+below. More strongly, one may "--ignore" given kinds of object
 such that they are not included among the duplicate in any way; if using
 this option then read on to the warning below about ignoring a linked-to
 class.
@@ -63,7 +63,8 @@ Examples:
         "--duplicate=CommentAnnotation,LongAnnotation\n"
         """
 Group permissions can prevent a duplicated link from referencing another
-user's Image or Annotation. However, note that ignoring a linked-to
+user's Image or Annotation, causing a duplication error.
+However, using "--ignore" instead of "--reference" for a linked-to
 class does not suffice, one must ignore the link itself. For instance,
 ignore ImageAnnotationLink or IAnnotationLink rather than the target
 Annotation. This is not an issue for classes such as Roi which can be

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -59,7 +59,15 @@ Examples:
         "    # Duplicate a project, linking to the original annotations "
         "except for duplicating the comments and ratings\n"
         "    omero duplicate Project:15 --reference-classes=Annotation "
-        "--duplicate-classes=CommentAnnotation,LongAnnotation\n\n")
+        "--duplicate-classes=CommentAnnotation,LongAnnotation\n"
+        """
+Group permissions can prevent simply referencing an Image or Annotation.
+However, note that ignoring a linked-to class does not suffice, one must
+ignore the link itself. For instance, ignore ImageAnnotationLink or
+IAnnotationLink rather than the target Annotation. This is not an issue
+for classes such as Roi which can be ignored directly because they have
+no separate link class.
+""")
 
 
 class DuplicateControl(GraphControl):

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -33,7 +33,7 @@ HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
 By default, a whole subtree of OMERO model objects is duplicated. One
 may opt to have duplicate objects reference original parts of the
 subtree instead of also duplicating those, see the "--reference" option
-below. More strongly, one may "--ignore" given kinds of object such that
+below. More strongly, one may "--ignore" given kinds of model objects such that
 they are not included among the duplicate in any way; if using this
 option then read on to the warning below about ignoring a linked-to
 class.


### PR DESCRIPTION
Fixes https://github.com/ome/omero-cli-duplicate/issues/7 and aids https://github.com/ome/design/issues/20 by adding command-line options to cover those of [omero::cmd::Duplicate](https://docs.openmicroscopy.org/omero-blitz/5.5.7/slice2html/omero/cmd/Duplicate.html).