### PR TITLE
Configure bumpversion to manage the release of this component

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 0.3.1.dev1
+commit = True
+tag = True
+sign_tags = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
+serialize = 
+	{major}.{minor}.{patch}.{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = prod
+first_value = dev
+values = 
+	dev
+	prod
+
+[bumpversion:part:build]
+
+[bumpversion:file:setup.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1.dev1
+current_version = 0.4.0.dev0
 commit = True
 tag = True
 sign_tags = True

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,24 @@ Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
     $ pip install -U omero-cli-duplicate
 
+Release process
+---------------
+
+This repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.
+To tag a release run::
+
+    $ bumpversion release
+
+This will remove the ``.dev0`` suffix from the current version, commit, and tag the release.
+
+To switch back to a development version run::
+
+    $ bumpversion --no-tag [major|minor|patch]
+
+specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
+
+Remember to ``git push`` all commits and tags.
+
 License
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.3.1.dev1'
+version = '0.4.0.dev0'
 url = "https://github.com/ome/omero-cli-duplicate/"
 
 setup(


### PR DESCRIPTION
This is the same approach used for other Python components

```
bumpversion release
```

should be sufficient to cut the next minor release of this plugin