### PR TITLE
Enable pipeline of duplicate output to, e.g., chgrp

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+cb487215cf775b8d6b32d6a33a36f1cb7fa689e2

--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Checkout omero-test-infra
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
-          repository: ome/omero-test-infra
+          repository: manics/omero-test-infra
           path: .omero
-          ref: ${{ secrets.OMERO_TEST_INFRA_REF }}
+          ref: pre-commit
       - name: Build and run OMERO tests
         run: .omero/docker $STAGE

--- a/.omeroci/bump-version
+++ b/.omeroci/bump-version
@@ -8,12 +8,14 @@ from os.path import pardir
 from re import compile
 
 setup_file = join(dirname(__file__), pardir, "setup.py")
-setup_re = compile("^(version\s=\s')\S+(')$")
+setup_re = compile(r"^(version\s=\s')\S+(')$")
+
 
 def replace_version(file, re, version):
     for line in input([file], inplace=1):
         replacement = r"\g<1>%s\g<2>" % version
-        print re.sub(replacement, line),
+        print(re.sub(replacement, line), end="")
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+---
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        args: [--target-version=py35]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        args: [
+          # default black line length is 88
+          --max-line-length=88,
+          # Conflicts with black: E203 whitespace before ':'
+          --extend-ignore=E203,
+        ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
     hooks:
       - id: black
         args: [--target-version=py35]
-  - repo: https://gitlab.com/pycqa/flake8
+  # GitLab URLs must include the .git suffix
+  # https://gitlab.com/gitlab-org/gitlab/-/issues/29629
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.3
     hooks:
       - id: flake8

--- a/setup.py
+++ b/setup.py
@@ -26,25 +26,24 @@ from setuptools.command.test import test as test_command
 
 class PyTest(test_command):
     user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
+        ("test-path=", "t", "base dir for test collection"),
+        ("test-ice-config=", "i", "use specified 'ice config' file instead of default"),
+        ("test-pythonpath=", "p", "prepend 'pythonpath' to PYTHONPATH"),
+        ("test-marker=", "m", "only run tests including 'marker'"),
+        ("test-no-capture", "s", "don't suppress test output"),
+        ("test-failfast", "x", "Exit on first error"),
+        ("test-verbose", "v", "more verbose output"),
+        ("test-quiet", "q", "less verbose output"),
+        ("junitxml=", None, "create junit-xml style report file at 'path'"),
+        ("pdb", None, "fallback to pdb on error"),
+    ]
 
     def initialize_options(self):
         test_command.initialize_options(self)
         self.test_pythonpath = None
         self.test_string = None
         self.test_marker = None
-        self.test_path = 'test'
+        self.test_path = "test"
         self.test_failfast = False
         self.test_quiet = False
         self.test_verbose = False
@@ -57,28 +56,29 @@ class PyTest(test_command):
         test_command.finalize_options(self)
         self.test_args = [self.test_path]
         if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
+            self.test_args.extend(["-k", self.test_string])
         if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
+            self.test_args.extend(["-m", self.test_marker])
         if self.test_failfast:
-            self.test_args.extend(['-x'])
+            self.test_args.extend(["-x"])
         if self.test_verbose:
-            self.test_args.extend(['-v'])
+            self.test_args.extend(["-v"])
         if self.test_quiet:
-            self.test_args.extend(['-q'])
+            self.test_args.extend(["-q"])
         if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
+            self.test_args.extend(["--junitxml", self.junitxml])
         if self.pdb:
-            self.test_args.extend(['--pdb'])
+            self.test_args.extend(["--pdb"])
         self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
+        if "ICE_CONFIG" not in os.environ:
+            os.environ["ICE_CONFIG"] = self.test_ice_config
 
     def run_tests(self):
         if self.test_pythonpath is not None:
             sys.path.insert(0, self.test_pythonpath)
         # import here, cause outside the eggs aren't loaded
         import pytest
+
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
@@ -91,44 +91,37 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.4.1.dev0'
+version = "0.4.1.dev0"
 url = "https://github.com/ome/omero-cli-duplicate/"
 
 setup(
     version=version,
-    packages=['', 'omero.plugins'],
+    packages=["", "omero.plugins"],
     package_dir={"": "src"},
-    name='omero-cli-duplicate',
+    name="omero-cli-duplicate",
     description="Plugin for use in the OMERO CLI.",
-    long_description=read('README.rst'),
+    long_description=read("README.rst"),
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Plugins',
-        'Intended Audience :: Developers',
-        'Intended Audience :: End Users/Desktop',
-        'License :: OSI Approved :: GNU General Public License v2 '
-        'or later (GPLv2+)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Plugins",
+        "Intended Audience :: Developers",
+        "Intended Audience :: End Users/Desktop",
+        "License :: OSI Approved :: GNU General Public License v2 " "or later (GPLv2+)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],  # Get strings from
-        # http://pypi.python.org/pypi?%3Aaction=list_classifiers
-    author='The Open Microscopy Team',
-    author_email='ome-devel@lists.openmicroscopy.org.uk',
-    license='GPL-2.0+',
-    url='%s' % url,
+    # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    author="The Open Microscopy Team",
+    author_email="ome-devel@lists.openmicroscopy.org.uk",
+    license="GPL-2.0+",
+    url="%s" % url,
     zip_safe=False,
-    download_url='%s/v%s.tar.gz' % (url, version),
-    install_requires=[
-        'omero-py>=5.8',
-        'future'
-    ],
-    python_requires='>=3',
-    keywords=['OMERO.CLI', 'plugin'],
-    cmdclass={'test': PyTest},
-    tests_require=[
-        'pytest',
-        'restview',
-        'mox3'],
+    download_url="%s/v%s.tar.gz" % (url, version),
+    install_requires=["omero-py>=5.8", "future"],
+    python_requires=">=3",
+    keywords=["OMERO.CLI", "plugin"],
+    cmdclass={"test": PyTest},
+    tests_require=["pytest", "restview", "mox3"],
 )

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -28,7 +28,8 @@ import sys
 
 from omero.cli import CLI, GraphControl
 
-HELP = ("""Duplicate graphs of OMERO data based on the ID of the top-node.
+HELP = (
+    """Duplicate graphs of OMERO data based on the ID of the top-node.
 
 By default, a whole subtree of OMERO model objects is duplicated. One
 may opt to have duplicate objects reference original parts of the
@@ -57,11 +58,11 @@ Examples:
     # Duplicate a project with the original images linked from its datasets
     omero duplicate Project:15 --reference Image
 """
-        "    # Duplicate a project, linking to the original annotations "
-        "except for duplicating the comments and ratings\n"
-        "    omero duplicate Project:15 --reference Annotation "
-        "--duplicate CommentAnnotation,LongAnnotation\n"
-        """
+    "    # Duplicate a project, linking to the original annotations "
+    "except for duplicating the comments and ratings\n"
+    "    omero duplicate Project:15 --reference Annotation "
+    "--duplicate CommentAnnotation,LongAnnotation\n"
+    """
 Group permissions can prevent a duplicated link from referencing another
 user's Image or Annotation, causing a duplication error. However, using
 "--ignore" instead of "--reference" for a linked-to class does not
@@ -69,14 +70,15 @@ suffice, one must ignore the link itself. For instance, ignore
 ImageAnnotationLink or IAnnotationLink rather than the target
 Annotation. This is not an issue for classes such as Roi which can be
 ignored directly because they have no separate link class.
-""")
+"""
+)
 
 
 class DuplicateControl(GraphControl):
-
     def cmd_type(self):
         import omero
         import omero.all
+
         return omero.cmd.Duplicate
 
     def _pre_objects(self, parser):
@@ -84,28 +86,40 @@ class DuplicateControl(GraphControl):
             "--duplicate",
             help="Specify kinds of object to duplicate",
             metavar="CLASS",
-            nargs="+", type=lambda s: s.split(","), action="append")
+            nargs="+",
+            type=lambda s: s.split(","),
+            action="append",
+        )
         parser.add_argument(
             "--reference",
-            help=("Specify kinds of object to "
-                  "link to instead of duplicate"),
+            help=("Specify kinds of object to " "link to instead of duplicate"),
             metavar="CLASS",
-            nargs="+", type=lambda s: s.split(","), action="append")
+            nargs="+",
+            type=lambda s: s.split(","),
+            action="append",
+        )
         parser.add_argument(
             "--ignore",
-            help=("Specify kinds of object to "
-                  "ignore, neither linking to nor duplicating"),
+            help=(
+                "Specify kinds of object to "
+                "ignore, neither linking to nor duplicating"
+            ),
             metavar="CLASS",
-            nargs="+", type=lambda s: s.split(","), action="append")
+            nargs="+",
+            type=lambda s: s.split(","),
+            action="append",
+        )
 
     def _process_request(self, req, args, client):
         import omero.cmd
+
         if isinstance(req, omero.cmd.DoAll):
             requests = req.requests
         else:
             requests = [req]
         for request in requests:
             from itertools import chain
+
             if isinstance(request, omero.cmd.SkipHead):
                 request = request.request
             if args.duplicate:
@@ -151,6 +165,7 @@ class DuplicateControl(GraphControl):
 
     def print_detailed_report(self, req, rsp, status):
         import omero
+
         if isinstance(rsp, omero.cmd.DoAllRsp):
             for response in rsp.responses:
                 if isinstance(response, omero.cmd.DuplicateResponse):

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -33,7 +33,6 @@ from mox3 import mox
 
 
 class AbstractCLITest(ITest):
-
     @classmethod
     def setup_class(cls):
         super(AbstractCLITest, cls).setup_class()
@@ -49,21 +48,20 @@ class AbstractCLITest(ITest):
 
 
 class CLITest(AbstractCLITest):
-
     def setup_method(self, method):
         self.args = self.login_args()
 
     def create_object(self, object_type, name=""):
         # create object
-        if object_type == 'Dataset':
+        if object_type == "Dataset":
             new_object = omero.model.DatasetI()
-        elif object_type == 'Project':
+        elif object_type == "Project":
             new_object = omero.model.ProjectI()
-        elif object_type == 'Plate':
+        elif object_type == "Plate":
             new_object = omero.model.PlateI()
-        elif object_type == 'Screen':
+        elif object_type == "Screen":
             new_object = omero.model.ScreenI()
-        elif object_type == 'Image':
+        elif object_type == "Image":
             new_object = self.new_image()
         new_object.name = rstring(name)
         new_object = self.update.saveAndReturnObject(new_object)
@@ -85,7 +83,6 @@ class CLITest(AbstractCLITest):
 
 
 class RootCLITest(AbstractCLITest):
-
     def setup_method(self, method):
         self.args = self.root_login_args()
 
@@ -116,43 +113,43 @@ class ArgumentFixture(object):
 
 
 UserIdNameFixtures = (
-    ArgumentFixture('--id', 'id'),
-    ArgumentFixture('--name', 'omeName'),
-    )
+    ArgumentFixture("--id", "id"),
+    ArgumentFixture("--name", "omeName"),
+)
 
 UserFixtures = (
-    ArgumentFixture(None, 'id'),
-    ArgumentFixture(None, 'omeName'),
-    ArgumentFixture('--user-id', 'id'),
-    ArgumentFixture('--user-name', 'omeName'),
-    )
+    ArgumentFixture(None, "id"),
+    ArgumentFixture(None, "omeName"),
+    ArgumentFixture("--user-id", "id"),
+    ArgumentFixture("--user-name", "omeName"),
+)
 
 GroupIdNameFixtures = (
-    ArgumentFixture('--id', 'id'),
-    ArgumentFixture('--name', 'name'),
-    )
+    ArgumentFixture("--id", "id"),
+    ArgumentFixture("--name", "name"),
+)
 
 GroupFixtures = (
-    ArgumentFixture(None, 'id'),
-    ArgumentFixture(None, 'name'),
-    ArgumentFixture('--group-id', 'id'),
-    ArgumentFixture('--group-name', 'name'),
-    )
+    ArgumentFixture(None, "id"),
+    ArgumentFixture(None, "name"),
+    ArgumentFixture("--group-id", "id"),
+    ArgumentFixture("--group-name", "name"),
+)
 
 
 def get_user_ids(out, sort_key=None):
-    columns = {'login': 1, 'first-name': 2, 'last-name': 3, 'email': 4}
-    lines = out.split('\n')
+    columns = {"login": 1, "first-name": 2, "last-name": 3, "email": 4}
+    lines = out.split("\n")
     ids = []
     last_value = None
     for line in lines[2:]:
-        elements = line.split('|')
+        elements = line.split("|")
         if len(elements) < 8:
             continue
 
         ids.append(int(elements[0].strip()))
         if sort_key:
-            if sort_key == 'id':
+            if sort_key == "id":
                 new_value = ids[-1]
             else:
                 new_value = elements[columns[sort_key]].strip()
@@ -162,17 +159,17 @@ def get_user_ids(out, sort_key=None):
 
 
 def get_group_ids(out, sort_key=None):
-    lines = out.split('\n')
+    lines = out.split("\n")
     ids = []
     last_value = None
     for line in lines[2:]:
-        elements = line.split('|')
+        elements = line.split("|")
         if len(elements) < 4:
             continue
 
         ids.append(int(elements[0].strip()))
         if sort_key:
-            if sort_key == 'id':
+            if sort_key == "id":
                 new_value = ids[-1]
             else:
                 new_value = elements[1].strip()

--- a/test/integration/clitest/test_duplicate.py
+++ b/test/integration/clitest/test_duplicate.py
@@ -29,7 +29,6 @@ model = ["", "I"]
 
 
 class TestDuplicate(CLITest):
-
     def setup_method(self, method):
         super(TestDuplicate, self).setup_method(method)
         self.cli.register("duplicate", DuplicateControl, "TEST")
@@ -44,9 +43,11 @@ class TestDuplicate(CLITest):
 
         params = omero.sys.ParametersI()
         params.addId(iid)
-        query = ("select d from Dataset as d where exists"
-                 "(select l from DatasetImageLink as l where "
-                 "l.child.id=:id and l.parent=d.id)")
+        query = (
+            "select d from Dataset as d where exists"
+            "(select l from DatasetImageLink as l where "
+            "l.child.id=:id and l.parent=d.id)"
+        )
         return self.query.findAllByQuery(query, params)
 
     def get_project(self, did):
@@ -54,9 +55,11 @@ class TestDuplicate(CLITest):
 
         params = omero.sys.ParametersI()
         params.addId(did)
-        query = ("select p from Project as p where exists"
-                 "(select l from ProjectDatasetLink as l where "
-                 "l.child.id=:id and l.parent=p.id)")
+        query = (
+            "select p from Project as p where exists"
+            "(select l from ProjectDatasetLink as l where "
+            "l.child.id=:id and l.parent=p.id)"
+        )
         return self.query.findAllByQuery(query, params)
 
     @pytest.mark.parametrize("model", model)
@@ -66,7 +69,7 @@ class TestDuplicate(CLITest):
         oid = self.create_object(object_type, name=name)
 
         # Duplicate the object
-        obj_arg = '%s%s:%s' % (object_type, model, oid)
+        obj_arg = "%s%s:%s" % (object_type, model, oid)
         self.args += [obj_arg]
         out = self.duplicate(capfd)
 
@@ -87,7 +90,7 @@ class TestDuplicate(CLITest):
         oid = self.create_object(object_type, name=name)
 
         # Duplicate the object
-        obj_arg = '%s:%s' % (object_type, oid)
+        obj_arg = "%s:%s" % (object_type, oid)
         self.args += [obj_arg, "--dry-run"]
         out = self.duplicate(capfd)
 
@@ -108,7 +111,7 @@ class TestDuplicate(CLITest):
         oid = self.create_object(object_type, name=name)
 
         # Duplicate the object
-        obj_arg = '%s:%s' % (object_type, oid)
+        obj_arg = "%s:%s" % (object_type, oid)
         self.args += [obj_arg, "--report"]
         out = self.duplicate(capfd)
         lines_out = out.splitlines()
@@ -122,8 +125,8 @@ class TestDuplicate(CLITest):
         assert len(objs) == 2
         assert objs[0].id.val != objs[1].id.val
         assert len(lines_out) == 6
-        assert '%s:%s' % (object_type, objs[0].id.val) in out
-        assert '%s:%s' % (object_type, objs[1].id.val) in out
+        assert "%s:%s" % (object_type, objs[0].id.val) in out
+        assert "%s:%s" % (object_type, objs[1].id.val) in out
 
     def test_duplicate_single_object_dry_run_report(self, capfd):
         name = self.uuid()
@@ -131,7 +134,7 @@ class TestDuplicate(CLITest):
         oid = self.create_object(object_type, name=name)
 
         # Duplicate the object
-        obj_arg = '%s:%s' % (object_type, oid)
+        obj_arg = "%s:%s" % (object_type, oid)
         self.args += [obj_arg, "--dry-run", "--report"]
         out = self.duplicate(capfd)
         lines_out = out.splitlines()
@@ -145,7 +148,7 @@ class TestDuplicate(CLITest):
         assert len(objs) == 1
         assert objs[0].id.val == oid
         assert len(lines_out) == 7
-        assert '%s:%s' % (object_type, objs[0].id.val) in out
+        assert "%s:%s" % (object_type, objs[0].id.val) in out
         # Check object has been found in two different places of the output
         assert out.find(obj_arg) != out.rfind(obj_arg)
 
@@ -160,8 +163,8 @@ class TestDuplicate(CLITest):
         self.link(proj, dset)
         self.link(dset, img)
 
-        self.args += ['Project:%s' % proj.id.val]
-        self.args += ['--report']
+        self.args += ["Project:%s" % proj.id.val]
+        self.args += ["--report"]
         out = self.duplicate(capfd)
 
         pp = omero.sys.ParametersI()
@@ -176,7 +179,7 @@ class TestDuplicate(CLITest):
         pid = max(objsp[0].id.val, objsp[1].id.val)
 
         # Check the duplicated Project is in the --report output
-        assert 'Project:%s' % pid in out
+        assert "Project:%s" % pid in out
 
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
@@ -192,7 +195,7 @@ class TestDuplicate(CLITest):
         proj_linked = self.get_project(did)
 
         # Check the duplicated Dataset is in the --report output
-        assert 'Dataset:%s' % did in out
+        assert "Dataset:%s" % did in out
 
         # Check the duplicated Dataset is linked to just the duplicated Project
         assert len(proj_linked) == 1
@@ -212,7 +215,7 @@ class TestDuplicate(CLITest):
         dat_linked = self.get_dataset(iid)
 
         # Check the duplicated Image is in the --report output
-        assert 'Image:%s' % iid in out
+        assert "Image:%s" % iid in out
 
         # Check the duplicated image is linked to just the duplicated Dataset
         assert len(dat_linked) == 1
@@ -227,8 +230,8 @@ class TestDuplicate(CLITest):
 
         self.link(proj, dset)
 
-        self.args += ['Project/Dataset:%s' % proj.id.val]
-        self.args += ['--report']
+        self.args += ["Project/Dataset:%s" % proj.id.val]
+        self.args += ["--report"]
         out = self.duplicate(capfd)
 
         pd = omero.sys.ParametersI()
@@ -243,7 +246,7 @@ class TestDuplicate(CLITest):
         did = max(objsd[0].id.val, objsd[1].id.val)
 
         # Check the duplicated Dataset is in the --report output
-        assert 'Dataset:%s' % did in out
+        assert "Dataset:%s" % did in out
 
         # Find the Projects linked to the duplicated dataset
         proj_linked = self.get_project(did)


### PR DESCRIPTION
In order to enable duplicate commands can exist in
a chain of pipelines, update the output of duplicate
runs to follow the "Class:ID" style.

Note that if `--report` is passed, the old-style
output remains.

see: https://forum.image.sc/t/same-image-file-in-multiple-omero-groups/45052/6