### PR TITLE
Integration tests: call pytest directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,5 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=[
         'pytest',
-        'restview',
-        'mox3'],
+        'restview'],
 )

--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,7 @@ setup(
     zip_safe=False,
     download_url='%s/v%s.tar.gz' % (url, version),
     install_requires=[
-        'omero-py>=5.8',
-        'future'
+        'omero-py>=5.8'
     ],
     python_requires='>=3',
     keywords=['OMERO.CLI', 'plugin'],

--- a/setup.py
+++ b/setup.py
@@ -18,69 +18,8 @@
 #
 #
 import os
-import sys
 
 from setuptools import setup
-from setuptools.command.test import test as test_command
-
-
-class PyTest(test_command):
-    user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
-
-    def initialize_options(self):
-        test_command.initialize_options(self)
-        self.test_pythonpath = None
-        self.test_string = None
-        self.test_marker = None
-        self.test_path = 'test'
-        self.test_failfast = False
-        self.test_quiet = False
-        self.test_verbose = False
-        self.test_no_capture = False
-        self.junitxml = None
-        self.pdb = False
-        self.test_ice_config = None
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = [self.test_path]
-        if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
-        if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
-        if self.test_failfast:
-            self.test_args.extend(['-x'])
-        if self.test_verbose:
-            self.test_args.extend(['-v'])
-        if self.test_quiet:
-            self.test_args.extend(['-q'])
-        if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
-        if self.pdb:
-            self.test_args.extend(['--pdb'])
-        self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
-
-    def run_tests(self):
-        if self.test_pythonpath is not None:
-            sys.path.insert(0, self.test_pythonpath)
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 def read(fname):
@@ -125,7 +64,6 @@ setup(
     ],
     python_requires='>=3',
     keywords=['OMERO.CLI', 'plugin'],
-    cmdclass={'test': PyTest},
     tests_require=[
         'pytest',
         'restview'],

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -20,7 +20,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-from builtins import object
 import pytest
 
 import omero

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -29,7 +29,6 @@ from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
 
 from omero.testlib import ITest
-from mox3 import mox
 
 
 class AbstractCLITest(ITest):
@@ -39,13 +38,6 @@ class AbstractCLITest(ITest):
         super(AbstractCLITest, cls).setup_class()
         cls.cli = CLI()
         cls.cli.register("sessions", SessionsControl, "TEST")
-
-    def setup_mock(self):
-        self.mox = mox.Mox()
-
-    def teardown_mock(self):
-        self.mox.UnsetStubs()
-        self.mox.VerifyAll()
 
 
 class CLITest(AbstractCLITest):


### PR DESCRIPTION
Depends on https://github.com/ome/omero-test-infra/pull/68

- deprecate the PyTest command and use pytest directly to run the tests
- remove all usages of the future library